### PR TITLE
Make haddockRender report file size and CRC32 (instead of filename)

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -18,6 +18,7 @@ dependencies:
     - base >= 4.7 && < 5
 
     - alfred-margaret
+    - bytestring
     - cairo
     - colour
     - containers

--- a/src/Data/Crc32.hs
+++ b/src/Data/Crc32.hs
@@ -1,0 +1,61 @@
+module Data.Crc32 (
+      crc32
+    , Crc32(..)
+) where
+
+
+
+import           Data.Bits
+import           Data.ByteString.Lazy (ByteString)
+import qualified Data.ByteString.Lazy as BSL
+import           Data.Vector          (Vector, (!))
+import qualified Data.Vector          as V
+import           Data.Word
+import           Text.Printf
+
+
+
+table :: Vector Word32
+table = createCrc32Table 0xedb88320
+
+createCrc32Table :: Word32 -> Vector Word32
+createCrc32Table poly = V.generate 256 $ \n -> V.foldl'
+    (\acc _ -> if odd acc
+        then poly `xor` shiftR acc 1
+        else shiftR acc 1
+        )
+    (fromIntegral n)
+    (V.enumFromN 0 8)
+
+-- fn crc32_compute_table() -> [u32; 256] {
+--     let mut crc32_table = [0; 256];
+--
+--     for n in 0..256 {
+--         crc32_table[n as usize] = (0..8).fold(n as u32, |acc, _| {
+--             match acc & 1 {
+--                 1 => 0xedb88320 ^ (acc >> 1),
+--                 _ => acc >> 1,
+--             }
+--         });
+--     }
+--
+--     crc32_table
+-- }
+
+newtype Crc32 = Crc32 Word32
+    deriving (Eq, Ord)
+
+instance Show Crc32 where show (Crc32 crc) = printf "%#08x" crc
+
+-- | CRC32 checksum.
+--
+-- >>> import Data.ByteString.Lazy.Char8
+-- >>> crc32 (pack "The quick brown fox jumps over the lazy dog")
+-- 0x414fa339
+--
+-- >>> crc32 (pack "123456789")
+-- 0xcbf43926
+crc32 :: ByteString -> Crc32
+crc32 bs =
+    let Crc32 crcResult = BSL.foldl' (\(Crc32 crc) byte -> Crc32 (xor (crc `shiftR` 8) (table ! fromIntegral (fromIntegral (crc .&. 0xff) `xor` byte)))) (Crc32 0xffffffff) bs
+    in Crc32 (complement crcResult)

--- a/src/Draw.hs
+++ b/src/Draw.hs
@@ -146,7 +146,7 @@ data CoordinateSystem
         --                       def {_arrowDrawBody=False})
         --         stroke
         -- :}
-        -- docs/haddock/Draw/coordinate_system_cairo_standard.svg
+        -- Generated file: size 2KB, crc32: 0x22a87e3e
 
     | MathStandard_ZeroBottomLeft_XRight_YUp Double
         -- ^ __Right-handed coordinate system.__ Standard math coordinates, with
@@ -172,7 +172,7 @@ data CoordinateSystem
         --                       def {_arrowDrawBody=False})
         --         stroke
         -- :}
-        -- docs/haddock/Draw/coordinate_system_math_standard.svg
+        -- Generated file: size 3KB, crc32: 0xd33a20ee
 
     | MathStandard_ZeroCenter_XRight_YUp Double Double
         -- ^ __Right-handed coordinate system.__ Standard math coordinates, with
@@ -198,7 +198,7 @@ data CoordinateSystem
         --                       def {_arrowDrawBody=False})
         --         stroke
         -- :}
-        -- docs/haddock/Draw/coordinate_system_math_standard_centered.svg
+        -- Generated file: size 3KB, crc32: 0xe6e10f11
 
     deriving (Eq, Ord, Show)
 
@@ -336,7 +336,7 @@ lineToVec (Vec2 x y) = lineTo x y
 --     sketch (Bezier (Vec2 10 10) (Vec2 50 200) (Vec2 100 (-50)) (Vec2 140 90))
 --     stroke
 -- :}
--- docs/haddock/Draw/instance_Sketch_Bezier.svg
+-- Generated file: size 2KB, crc32: 0xe17dab02
 instance Sketch Bezier where
     sketch (Bezier start (Vec2 x1 y1) (Vec2 x2 y2) (Vec2 x3 y3)) = do
         moveToVec start
@@ -387,7 +387,7 @@ data Arrow = Arrow !Line !ArrowSpec
 --     sketch (Arrow (Line (Vec2 10 10) (Vec2 140 90)) def)
 --     stroke
 -- :}
--- docs/haddock/Draw/instance_Sketch_Arrow.svg
+-- Generated file: size 2KB, crc32: 0x2c724862
 instance Sketch Arrow where
     sketch (Arrow line ArrowSpec{..}) = do
         when _arrowDrawBody (sketch line)
@@ -448,7 +448,7 @@ instance Sketch a => Sketch (Maybe a) where
 --     sketch (Line (Vec2 10 10) (Vec2 140 90))
 --     stroke
 -- :}
--- docs/haddock/Draw/instance_Sketch_Line.svg
+-- Generated file: size 2KB, crc32: 0x9287e4a8
 instance Sketch Line where
     sketch (Line start end) = do
         moveToVec start
@@ -465,7 +465,7 @@ instance Sketch Line where
 --     sketch (Polyline [Vec2 10 10, Vec2 90 90, Vec2 120 10, Vec2 140 50])
 --     stroke
 -- :}
--- docs/haddock/Draw/instance_Sketch_Sequential_Vec2.svg
+-- Generated file: size 2KB, crc32: 0x5d5a0158
 instance Sketch Polyline where
     sketch (Polyline xs) = go xs
       where
@@ -484,7 +484,7 @@ instance Sketch Polyline where
 --     sketch (Polygon [Vec2 20 10, Vec2 10 80, Vec2 45 45, Vec2 60 90, Vec2 90 30])
 --     stroke
 -- :}
--- docs/haddock/Draw/instance_Sketch_Polygon.svg
+-- Generated file: size 2KB, crc32: 0x7f620554
 instance Sketch Polygon where
     sketch (Polygon []) = pure ()
     sketch (Polygon xs) = sketch (Polyline xs) >> closePath
@@ -498,7 +498,7 @@ instance Sketch Polygon where
 --     sketch (Circle (Vec2 50 50) 45)
 --     stroke
 -- :}
--- docs/haddock/Draw/instance_Sketch_Circle.svg
+-- Generated file: size 2KB, crc32: 0xebd35c6d
 instance Sketch Circle where
     sketch (Circle (Vec2 x y) r) = arc x y r 0 (2*pi)
 
@@ -513,7 +513,7 @@ instance Sketch Circle where
 --                         (toEllipse (Circle zero 45)))
 --     stroke
 -- :}
--- docs/haddock/Draw/instance_Sketch_Ellipse.svg
+-- Generated file: size 2KB, crc32: 0x25bae2ef
 --
 instance Sketch Ellipse where
     sketch (Ellipse t) = cairoScope $ do
@@ -540,7 +540,7 @@ data Cross = Cross
 --     sketch (Cross  (Vec2 60 20) 15) >> stroke
 --     sketch (Circle (Vec2 60 20) 15) >> stroke
 -- :}
--- docs/haddock/Draw/instance_Sketch_Cross.svg
+-- Generated file: size 2KB, crc32: 0xe2cb8567
 instance Sketch Cross where
     sketch (Cross center r) = do
         let lowerRight = G.transform (rotateAround center (deg 45)) (center +. Vec2 r 0)
@@ -562,7 +562,7 @@ instance Sketch Cross where
 --     setColor (mathematica97 1) >> sketch (G.translate (Vec2 110 50) <> G.rotate (deg 30)) >> stroke
 --     setColor (mathematica97 2) >> sketch (G.shear 0.5 0.2 <> G.translate (Vec2 140 0)) >> stroke
 -- :}
--- docs/haddock/Draw/instance_Sketch_Transformation.svg
+-- Generated file: size 4KB, crc32: 0x1f4ae5da
 instance Sketch Transformation where
     sketch t = do
         let grid = [Line (Vec2 0 y) (Vec2 100 y) | y <- map fromIntegral [0,20..100]]
@@ -601,7 +601,7 @@ arcSketchNegative (Vec2 x y) r angleStart angleEnd
 --     sketch (boundingBox geometry)
 --     stroke
 -- :}
--- docs/haddock/Draw/instance_Sketch_BoundingBox.svg
+-- Generated file: size 3KB, crc32: 0xfed2c044
 instance Sketch BoundingBox where
     sketch (BoundingBox (Vec2 xlo ylo) (Vec2 xhi yhi)) = do
         let w = xhi - xlo
@@ -644,7 +644,7 @@ instance Default CartesianParams where
 -- >>> :{
 -- haddockRender "Draw/cartesianCoordinateSystem.svg" 320 220 (cartesianCoordinateSystem def)
 -- :}
--- docs/haddock/Draw/cartesianCoordinateSystem.svg
+-- Generated file: size 21KB, crc32: 0xf43aac0c
 cartesianCoordinateSystem :: CartesianParams -> Render ()
 cartesianCoordinateSystem params@CartesianParams{..}  = grouped (paintWithAlpha _cartesianAlpha) $ do
     let vec2 x y = Vec2 (fromIntegral x) (fromIntegral y)
@@ -706,7 +706,7 @@ instance Default PolarParams where
 --     C.translate 50 50
 --     radialCoordinateSystem def
 -- :}
--- docs/haddock/Draw/radialCoordinateSystem.svg
+-- Generated file: size 26KB, crc32: 0x9b68b36
 radialCoordinateSystem :: PolarParams -> Render ()
 radialCoordinateSystem PolarParams{_polarCenter=center, _polarMaxRadius=maxR} = cairoScope $ do
     setLineWidth 1
@@ -771,7 +771,7 @@ withOperator op actions = do
 --     sketch line
 --     stroke
 -- :}
--- docs/haddock/Draw/cairoScope.svg
+-- Generated file: size 2KB, crc32: 0x2d7bee90
 --
 -- <<docs/haddock/Draw/cairoScope.svg>>
 cairoScope :: Render a -> Render a

--- a/src/Draw/Color.hs
+++ b/src/Draw/Color.hs
@@ -50,7 +50,7 @@ class CairoColor color where
     --         sketch (Circle (Vec2 x 20) 10)
     --         C.fill
     -- :}
-    -- docs/haddock/Draw/Color/set_color.svg
+    -- Generated file: size 4KB, crc32: 0xe0e16234
     --
     -- <<docs/haddock/Draw/Color/set_color.svg>>
     setColor :: color -> C.Render ()

--- a/src/Draw/Plotting.hs
+++ b/src/Draw/Plotting.hs
@@ -16,7 +16,7 @@
 --             for_ geometry $ \logoPart -> plot logoPart
 --     _plotPreview plotResult
 -- :}
--- docs/haddock/Draw/Plotting/example.svg
+-- Generated file: size 10KB, crc32: 0x1e175925
 module Draw.Plotting (
     -- * 'Plot' type
       Plot()

--- a/src/Draw/Text.hs
+++ b/src/Draw/Text.hs
@@ -45,7 +45,7 @@ data HAlign = HLeft | HCenter | HRight deriving (Eq, Ord, Show)
 --     C.scale 3 3
 --     showTextAligned HCenter VCenter "Hello world!"
 -- :}
--- docs/haddock/Draw/Text/show_text_aligned.svg
+-- Generated file: size 8KB, crc32: 0xefcaecf4
 showTextAligned
     :: C.CairoString string
     => HAlign -- ^ Horizontal alignment
@@ -103,7 +103,7 @@ instance Default PlotTextOptions where
 --         glyphs = plotText opts "Hello world!"
 --     for_ glyphs $ \glyph -> sketch glyph >> stroke
 -- :}
--- docs/haddock/Draw/Text/plot_text.svg
+-- Generated file: size 7KB, crc32: 0xd253d9dd
 plotText :: PlotTextOptions -> String -> [Polyline]
 plotText options text = transform (translate (_textStartingPoint options) <> scaleToHeight <> halign <> valign) glyphs
   where

--- a/src/Geometry/Algorithms/Clipping.hs
+++ b/src/Geometry/Algorithms/Clipping.hs
@@ -35,7 +35,7 @@
 --         setColor (mathematica97 i)
 --         stroke
 -- :}
--- docs/haddock/Geometry/Algorithms/Clipping/complicated_intersection.svg
+-- Generated file: size 5KB, crc32: 0xd81cbd60
 module Geometry.Algorithms.Clipping (
       cutLineWithLine
     , CutLine(..)
@@ -85,7 +85,7 @@ import Geometry.Core
 --     sketch polygon
 --     stroke
 -- :}
--- docs/haddock/Geometry/Algorithms/Clipping/hatched_polygon.svg
+-- Generated file: size 2KB, crc32: 0x81dce6d7
 hatch
     :: Polygon
     -> Angle -- ^ Direction in which the lines will point. @'deg' 0@ is parallel to the x axis.

--- a/src/Geometry/Algorithms/Clipping/CohenSutherland.hs
+++ b/src/Geometry/Algorithms/Clipping/CohenSutherland.hs
@@ -46,7 +46,7 @@ import Util
 --         sketch (boundingBoxPolygon mask)
 --         C.stroke
 -- :}
--- docs/haddock/Geometry/Algorithms/Clipping/CohenSutherland/cohenSutherland.svg
+-- Generated file: size 22KB, crc32: 0xa5dc883f
 cohenSutherland :: BoundingBox -> Line -> Maybe Line
 cohenSutherland bb = \line -> let Line start end = line in loop line (outCode start) (outCode end)
   where

--- a/src/Geometry/Algorithms/Clipping/MargalitKnott.hs
+++ b/src/Geometry/Algorithms/Clipping/MargalitKnott.hs
@@ -320,7 +320,7 @@ margalitKnott op Regular (polygonA, polygonA_Type) (polygonB', polygonB_Type) =
 --         fill
 --     sketch (p1, p2) >> stroke
 -- :}
--- docs/haddock/Geometry/Algorithms/Clipping/MargalitKnott/union.svg
+-- Generated file: size 2KB, crc32: 0xcc4c9f5e
 unionPP :: Polygon -> Polygon -> [(Polygon, IslandOrHole)]
 unionPP = ppBinop Union
 
@@ -342,7 +342,7 @@ unionPP = ppBinop Union
 --         fill
 --     sketch (p1, p2) >> stroke
 -- :}
--- docs/haddock/Geometry/Algorithms/Clipping/MargalitKnott/intersection.svg
+-- Generated file: size 2KB, crc32: 0xdaf13db5
 intersectionPP :: Polygon -> Polygon -> [(Polygon, IslandOrHole)]
 intersectionPP = ppBinop Intersection
 
@@ -361,7 +361,7 @@ intersectionPP = ppBinop Intersection
 --         fill
 --     sketch (p1, p2) >> stroke
 -- :}
--- docs/haddock/Geometry/Algorithms/Clipping/MargalitKnott/difference.svg
+-- Generated file: size 2KB, crc32: 0x9388b325
 differencePP
     :: Polygon -- ^ A
     -> Polygon -- ^ B

--- a/src/Geometry/Algorithms/Clipping/SutherlandHodgman.hs
+++ b/src/Geometry/Algorithms/Clipping/SutherlandHodgman.hs
@@ -28,7 +28,7 @@ import Geometry.Core
 --     sketch subject >> setColor (mathematica97 1) >> stroke
 --     sketch scissors >> setColor (mathematica97 3) >> setDash [3,3] 0 >> stroke
 -- :}
--- docs/haddock/Geometry/Algorithms/Clipping/SutherlandHodgman/sutherland_hodgman.svg
+-- Generated file: size 2KB, crc32: 0x722cb97a
 sutherlandHodgman
     :: Polygon -- ^ Subject
     -> Polygon -- ^ __Convex__ scissors

--- a/src/Geometry/Algorithms/Delaunay.hs
+++ b/src/Geometry/Algorithms/Delaunay.hs
@@ -50,7 +50,7 @@
 --         sketch edge
 --         stroke
 -- :}
--- docs/haddock/Geometry/Algorithms/Delaunay/delaunay_voronoi.svg
+-- Generated file: size 729KB, crc32: 0x640a6e45
 module Geometry.Algorithms.Delaunay (
     -- * Core
       delaunayTriangulation
@@ -142,7 +142,7 @@ delaunayTriangulation = Api.delaunayTriangulation . toVector
 --         sketch (growPolygon (-2) triangle)
 --         fill
 -- :}
--- docs/haddock/Geometry/Algorithms/Delaunay/triangles.svg
+-- Generated file: size 48KB, crc32: 0x960a4150
 delaunayTriangles :: Api.DelaunayTriangulation -> Vector Polygon
 delaunayTriangles = Api._triangles
 
@@ -167,7 +167,7 @@ delaunayTriangles = Api._triangles
 --         sketch edge
 --         stroke
 -- :}
--- docs/haddock/Geometry/Algorithms/Delaunay/edges.svg
+-- Generated file: size 97KB, crc32: 0xc283d1df
 delaunayEdges :: Api.DelaunayTriangulation -> Vector Line
 delaunayEdges = Api._edges
 
@@ -198,7 +198,7 @@ delaunayEdges = Api._edges
 --         sketch (Circle corner 2)
 --         fill
 -- :}
--- docs/haddock/Geometry/Algorithms/Delaunay/voronoi_corners.svg
+-- Generated file: size 155KB, crc32: 0xfd606083
 voronoiCorners :: Api.DelaunayTriangulation -> Vector Vec2
 voronoiCorners = Api._voronoiCorners
 
@@ -227,7 +227,7 @@ voronoiCorners = Api._voronoiCorners
 --         sketch edge
 --         stroke
 -- :}
--- docs/haddock/Geometry/Algorithms/Delaunay/voronoi_edges.svg
+-- Generated file: size 94KB, crc32: 0x8e95bd19
 voronoiEdges :: Api.DelaunayTriangulation -> Vector (Either Line Api.Ray)
 voronoiEdges = Api._voronoiEdges
 
@@ -258,7 +258,7 @@ voronoiEdges = Api._voronoiEdges
 --         sketch (growPolygon (-2) polygon)
 --         fill
 -- :}
--- docs/haddock/Geometry/Algorithms/Delaunay/voronoi_cells.svg
+-- Generated file: size 37KB, crc32: 0x8587a040
 voronoiCells :: Api.DelaunayTriangulation -> Vector Api.VoronoiPolygon
 voronoiCells = Api._voronoiCells
 
@@ -287,7 +287,7 @@ voronoiCells = Api._voronoiCells
 --         setColor (mathematica97 3)
 --         fill
 -- :}
--- docs/haddock/Geometry/Algorithms/Delaunay/convex_hull.svg
+-- Generated file: size 37KB, crc32: 0x461696a3
 delaunayHull :: Api.DelaunayTriangulation -> Vector Vec2
 delaunayHull = Api._convexHull
 
@@ -335,7 +335,7 @@ delaunayHull = Api._convexHull
 --             setColor (mathematica97 i)
 --             sketch (Line needle closest) >> stroke
 -- :}
--- docs/haddock/Geometry/Algorithms/Delaunay/find_triangle.svg
+-- Generated file: size 181KB, crc32: 0x6d8c142f
 findClosestInputPoint
     :: Api.DelaunayTriangulation
     -> Vec2 -- ^ Needle
@@ -380,7 +380,7 @@ findClosestInputPoint = Api._findClosestInputPoint
 --         sketch (growPolygon (-2) polygon)
 --         fill
 -- :}
--- docs/haddock/Geometry/Algorithms/Delaunay/lloyd_relaxation.svg
+-- Generated file: size 37KB, crc32: 0x7130f1e1
 lloydRelaxation
     :: (HasBoundingBox boundingBox, Sequential vector)
     => boundingBox

--- a/src/Geometry/Algorithms/Sampling.hs
+++ b/src/Geometry/Algorithms/Sampling.hs
@@ -48,7 +48,7 @@ import Geometry.Algorithms.Sampling.PoissonDisc
 --         sketch (Circle p 2)
 --         fill
 -- :}
--- docs/haddock/Geometry/Algorithms/Sampling/uniform.svg
+-- Generated file: size 263KB, crc32: 0x29e19f0e
 uniformlyDistributedPoints
     :: (PrimMonad m, HasBoundingBox boundingBox)
     => Gen (PrimState m) -- ^ RNG from mwc-random. 'create' yields the default (static) RNG.
@@ -81,7 +81,7 @@ uniformlyDistributedPoints gen bb count = V.replicateM count randomPoint
 --         sketch (Circle p 2)
 --         fill
 -- :}
--- docs/haddock/Geometry/Algorithms/Sampling/gaussian.svg
+-- Generated file: size 267KB, crc32: 0xdffc4138
 gaussianDistributedPoints
     :: (PrimMonad m, HasBoundingBox boundingBox)
     => Gen (PrimState m) -- ^ RNG from mwc-random. 'create' yields the default (static) RNG.
@@ -125,7 +125,7 @@ gaussianDistributedPoints gen container covariance count = V.replicateM count ra
 --         sketch (Circle p 2)
 --         fill
 -- :}
--- docs/haddock/Geometry/Algorithms/Sampling/rejection.svg
+-- Generated file: size 263KB, crc32: 0x38511a1
 rejection
     :: (PrimMonad m, HasBoundingBox boundingBox)
     => Gen (PrimState m) -- ^ RNG from mwc-random. 'create' yields the default (static) RNG.

--- a/src/Geometry/Algorithms/Sampling/PoissonDisc.hs
+++ b/src/Geometry/Algorithms/Sampling/PoissonDisc.hs
@@ -51,7 +51,7 @@ newtype CellSize = CellSize Double
 --         sketch (Circle p 2)
 --         fill
 -- :}
--- docs/haddock/Geometry/Algorithms/Sampling/PoissonDisc/poisson_disc.svg
+-- Generated file: size 115KB, crc32: 0x43236d3e
 poissonDisc
     :: (PrimMonad m, HasBoundingBox boundingBox)
     => Gen (PrimState m) -- ^ RNG from mwc-random. 'create' yields the default (static) RNG.
@@ -119,7 +119,7 @@ poissonDisc gen bb' radius k = do
 --                     paint color (i+1) child
 --     for_ (zip [flare, crest, flare] initialPoints) $ \(color, p0) -> paint color 0 p0
 -- :}
--- docs/haddock/Geometry/Algorithms/Sampling/PoissonDisc/poisson_disc_forest.svg
+-- Generated file: size 474KB, crc32: 0x28fe4a90
 poissonDiscForest
     :: (PrimMonad m, HasBoundingBox boundingBox)
     => Gen (PrimState m)       -- ^ RNG from mwc-random. 'create' yields the default (static) RNG.

--- a/src/Geometry/Algorithms/Triangulate.hs
+++ b/src/Geometry/Algorithms/Triangulate.hs
@@ -44,7 +44,7 @@ import Util
 --         sketch polygon
 --         C.stroke
 -- :}
--- docs/haddock/Geometry/Algorithms/Triangulate/triangulate.svg
+-- Generated file: size 4KB, crc32: 0xf8dda52c
 triangulate :: Polygon -> [Polygon]
 triangulate polygon = case clipEar polygon of
     (ear, Nothing) -> [ear]

--- a/src/Geometry/Bezier.hs
+++ b/src/Geometry/Bezier.hs
@@ -188,7 +188,7 @@ bezierSubdivideT n bz = map (bezierT bz) points
 --         cairoScope (setColor (mathematica97 3) >> circle u)
 --         cairoScope (setColor (black `withOpacity` 0.2) >> connect e u)
 -- :}
--- docs/haddock/Geometry/Bezier/subdivide_s_t_comparison.svg
+-- Generated file: size 17KB, crc32: 0x7c147951
 bezierSubdivideS :: Int -> Bezier -> [Vec2]
 bezierSubdivideS n bz = map bezier distances
   where
@@ -301,7 +301,7 @@ s_to_t_lut_ode bz ds = LookupTable1 (sol_to_vec sol)
 --     C.setLineWidth 2
 --     for_ (bezierSmoothenLoop points) prettyBezier
 -- :}
--- docs/haddock/Geometry/Bezier/bezierSmoothen.svg
+-- Generated file: size 15KB, crc32: 0x9f26361e
 bezierSmoothen :: Sequential vector => vector Vec2 -> Vector Bezier
 bezierSmoothen vecSequence
     | V.head vec == V.last vec = bezierSmoothenLoop vec

--- a/src/Geometry/Coordinates/Hexagonal.hs
+++ b/src/Geometry/Coordinates/Hexagonal.hs
@@ -27,7 +27,7 @@
 --         setColor black
 --         C.stroke
 -- :}
--- docs/haddock/Geometry/Coordinates/Hexagonal/cubes.svg
+-- Generated file: size 194KB, crc32: 0xcde33b0b
 module Geometry.Coordinates.Hexagonal (
       Hex(..)
     , toVec2
@@ -354,7 +354,7 @@ cubeLerp (Hex q1 r1) (Hex q2 r2) t =
 --         setColor (mathematica97 0 `withOpacity` 0.5)
 --         C.stroke
 -- :}
--- docs/haddock/Geometry/Coordinates/Hexagonal/line.svg
+-- Generated file: size 6KB, crc32: 0x5ec289a8
 line :: Hex -> Hex -> [Hex]
 line start end =
     let d = distance start end
@@ -380,7 +380,7 @@ line start end =
 --         setColor (mathematica97 1 `withOpacity` 0.5)
 --         C.stroke
 -- :}
--- docs/haddock/Geometry/Coordinates/Hexagonal/ring.svg
+-- Generated file: size 7KB, crc32: 0xacce7f95
 ring
     :: Int -- ^ Radius
     -> Hex -- ^ Center

--- a/src/Geometry/Core.hs
+++ b/src/Geometry/Core.hs
@@ -434,7 +434,7 @@ instance (Transform a, Transform b, Transform c, Transform d, Transform e) => Tr
 --     setColor (mathematica97 1)
 --     sketch (Arrow (Line point point') def) >> C.stroke
 -- :}
--- docs/haddock/Geometry/Core/translate.svg
+-- Generated file: size 2KB, crc32: 0x93f965ed
 translate :: Vec2 -> Transformation
 translate = Transformation mempty
 
@@ -471,7 +471,7 @@ translate = Transformation mempty
 --         sketch (Arrow (transform (rotateAround point' (deg 15)) (Line point point')) def{_arrowDrawBody=False})
 --         C.stroke
 -- :}
--- docs/haddock/Geometry/Core/rotate.svg
+-- Generated file: size 2KB, crc32: 0x980f5f
 rotate :: Angle -> Transformation
 rotate (Rad a) = Transformation m zero
   where
@@ -497,7 +497,7 @@ rotateAround pivot angle = translate pivot <> rotate angle <> inverse (translate
 --     sketch square'
 --     C.stroke
 -- :}
--- docs/haddock/Geometry/Core/scale.svg
+-- Generated file: size 2KB, crc32: 0x9126ef6
 scale :: Double -> Transformation
 scale x = scale' x x
 
@@ -567,7 +567,7 @@ mirrorYCoords = scale' 1 (-1)
 --     sketch square'
 --     C.stroke
 -- :}
--- docs/haddock/Geometry/Core/shear.svg
+-- Generated file: size 2KB, crc32: 0xfd1224e4
 shear
     :: Double
     -> Double
@@ -681,7 +681,7 @@ instance Transform a => Transform (NoBoundingBox a) where transform t (NoBoundin
 --     setColor (mathematica97 1)
 --     sketch (boundingBoxPolygon points) >> C.setLineWidth 3 >> C.stroke
 -- :}
--- docs/haddock/Geometry/Core/boundingBoxPolygon.svg
+-- Generated file: size 25KB, crc32: 0x40902165
 boundingBoxPolygon :: HasBoundingBox object => object -> Polygon
 boundingBoxPolygon object = Polygon [Vec2 x1 y1, Vec2 x2 y1, Vec2 x2 y2, Vec2 x1 y2]
   where BoundingBox (Vec2 x1 y1) (Vec2 x2 y2) = boundingBox object
@@ -713,7 +713,7 @@ boundingBoxPolygon object = Polygon [Vec2 x1 y1, Vec2 x2 y1, Vec2 x2 y2, Vec2 x1
 --     setColor (mathematica97 2) >> paintCheck (Line (Vec2 20 40) (Vec2 60 90))
 --     setColor (mathematica97 4) >> paintCheck (transform (translate (Vec2 130 130) <> scale 30) (Geometry.Shapes.regularPolygon 5))
 -- :}
--- docs/haddock/Geometry/Core/insideBoundingBox.svg
+-- Generated file: size 5KB, crc32: 0x8c351375
 insideBoundingBox :: (HasBoundingBox thing, HasBoundingBox bigObject) => thing -> bigObject -> Bool
 insideBoundingBox thing bigObject =
     let thingBB = boundingBox thing
@@ -739,7 +739,7 @@ insideBoundingBox thing bigObject =
 --     sketch (Circle (boundingBoxCenter pointsBB) 10)
 --     C.stroke
 -- :}
--- docs/haddock/Geometry/Core/boundingBoxCenter.svg
+-- Generated file: size 25KB, crc32: 0x31972ee1
 boundingBoxCenter :: HasBoundingBox a => a -> Vec2
 boundingBoxCenter x = let BoundingBox lo hi = boundingBox x in (lo+.hi)/.2
 
@@ -762,7 +762,7 @@ boundingBoxCenter x = let BoundingBox lo hi = boundingBox x in (lo+.hi)/.2
 --     for_ p2s $ \p -> sketch (Circle p 3) >> setColor (mathematica97 1) >> C.fill
 --     sketch (fmap boundingBoxPolygon (boundingBoxIntersection p1s p2s)) >> setColor (mathematica97 3) >> C.stroke
 -- :}
--- docs/haddock/Geometry/Core/boundingBoxIntersection.svg
+-- Generated file: size 25KB, crc32: 0x72cfba9f
 boundingBoxIntersection
     :: (HasBoundingBox a, HasBoundingBox b)
     => a
@@ -807,7 +807,7 @@ boundingBoxSize x = (abs deltaX, abs deltaY)
 --         setColor (icefire (Numerics.Interpolation.lerp (0,25) (0.5, 1) (fromIntegral amount)))
 --         C.stroke
 -- :}
--- docs/haddock/Geometry/Core/growBoundingBox.svg
+-- Generated file: size 4KB, crc32: 0xedcda2c4
 growBoundingBox
     :: HasBoundingBox boundingBox
     => Double -- ^ Amount \(x\) to move each side. Note that e.g. the total width will increase by \(2\times x\).
@@ -833,7 +833,7 @@ growBoundingBox delta stuff  =
 --         setColor (icefire (Numerics.Interpolation.lerp (0,25) (0.5, 0) (fromIntegral amount)))
 --         C.stroke
 -- :}
--- docs/haddock/Geometry/Core/shrinkBoundingBox.svg
+-- Generated file: size 4KB, crc32: 0xe0236688
 shrinkBoundingBox :: HasBoundingBox boundingBox => Double -> boundingBox -> BoundingBox
 shrinkBoundingBox delta = growBoundingBox (-delta)
 
@@ -1034,7 +1034,7 @@ normSquare v = dotProduct v v
 --         sketch (Circle p 3)
 --         C.fill
 -- :}
--- docs/haddock/Geometry/Core/polar.svg
+-- Generated file: size 2KB, crc32: 0x7a43a888
 polar :: Angle -> Double -> Vec2
 polar (Rad a) d = Vec2 (d * cos a) (d * sin a)
 
@@ -1127,7 +1127,7 @@ normalizeAngle start a = rad (getRad (a -. start) `rem'` (2*pi)) +. start
 --         setColor (mathematica97 1)
 --         C.stroke
 -- :}
--- docs/haddock/Geometry/Core/pseudo_angle.svg
+-- Generated file: size 5KB, crc32: 0xda270ddb
 pseudoAngle :: Vec2 -> Double
 pseudoAngle (Vec2 x y) = pseudoAtan2 y x
 
@@ -1241,7 +1241,7 @@ direction = vectorOf . normalizeLine
 --         sketch (Arrow line' def)
 --         C.stroke
 -- :}
--- docs/haddock/Geometry/Core/line_reverse.svg
+-- Generated file: size 2KB, crc32: 0xc8ad41ff
 lineReverse :: Line -> Line
 lineReverse (Line start end) = Line end start
 
@@ -1369,7 +1369,7 @@ intersectionLL lineL lineR
 --         setColor (mathematica97 1)
 --         C.fill
 -- :}
--- docs/haddock/Geometry/Core/subdivide_line.svg
+-- Generated file: size 4KB, crc32: 0x527103e6
 subdivideLine :: Int -> Line -> [Vec2]
 subdivideLine _ (Line start end) | start == end = [start, end]
 subdivideLine numSegments line@(Line start end) = do
@@ -1403,7 +1403,7 @@ subdivideLine numSegments line@(Line start end) = do
 --         setColor (mathematica97 1)
 --         C.fill
 -- :}
--- docs/haddock/Geometry/Core/subdivide_line_by_length.svg
+-- Generated file: size 4KB, crc32: 0x6180122d
 subdivideLineByLength
     :: Double -- ^ Maximum segment length
     -> Line
@@ -1426,7 +1426,7 @@ subdivideLineByLength segmentLength line =
 --         sketch edge
 --         C.stroke
 -- :}
--- docs/haddock/Geometry/Core/polygon_edges.svg
+-- Generated file: size 3KB, crc32: 0x9c27134b
 polygonEdges :: Polygon -> [Line]
 polygonEdges (Polygon ps) = zipWith Line ps (tail (cycle ps))
 
@@ -1462,7 +1462,7 @@ polygonAngles polygon@(Polygon corners)
 --         sketch (Arrow edge def{_arrowheadRelPos=0.5, _arrowheadSize=5})
 --     C.stroke
 -- :}
--- docs/haddock/Geometry/Core/convex_hull.svg
+-- Generated file: size 29KB, crc32: 0xe4bf922
 convexHull :: Foldable list => list Vec2 -> Polygon
 -- Andrew’s algorithm
 convexHull points
@@ -1617,7 +1617,7 @@ toEllipse (Circle center radius) = Ellipse (translate center <> scale radius)
 -- >>>        setColor (mathematica97 i)
 -- >>>        action
 -- :}
--- docs/haddock/Geometry/Core/ellipses.svg
+-- Generated file: size 42KB, crc32: 0xb3cabf7b
 newtype Ellipse = Ellipse Transformation
     deriving (Show)
 
@@ -1652,7 +1652,7 @@ instance Default Ellipse where def = Ellipse mempty
 -- >>>     paintWithBB 1 2 (transform (shear 0 0.3 <> scale' 1 0.5) ellipse)
 -- >>>     paintWithBB 2 2 (transform (scale' 1 0.5 <> rotate (deg 45) <> shear 0 1 <> scale' 1 0.5) ellipse)
 -- :}
--- docs/haddock/Geometry/Core/bounding_box_ellipse.svg
+-- Generated file: size 9KB, crc32: 0xac92bb50
 instance HasBoundingBox Ellipse where
     boundingBox (Ellipse (Transformation (Mat2 a11 a12 a21 a22) (Vec2 b1 b2))) =
         let -- https://tavianator.com/2014/ellipsoid_bounding_boxes.html
@@ -1730,7 +1730,7 @@ countEdgeTraversals subjectPoint edges'
 --         sketch (Circle point 4)
 --         if pointInPolygon point square then C.fill else C.stroke
 -- :}
--- docs/haddock/Geometry/Core/point_in_polygon.svg
+-- Generated file: size 5KB, crc32: 0xabb5dfc
 pointInPolygon :: Vec2 -> Polygon -> Bool
 pointInPolygon p poly = odd (countEdgeTraversals p (polygonEdges poly))
 
@@ -1796,7 +1796,7 @@ validatePolygon = \polygon -> do
 --     sketch (Cross averate 5)
 --     C.stroke
 -- :}
--- docs/haddock/Geometry/Core/polygon_average.svg
+-- Generated file: size 2KB, crc32: 0xcf7a8233
 polygonAverage :: Polygon -> Vec2
 polygonAverage (Polygon corners)
   = let (num, total) = foldl' (\(!n, !vec) corner -> (n+1, vec +. corner)) (0, Vec2 0 0) corners
@@ -1818,7 +1818,7 @@ polygonAverage (Polygon corners)
 --     sketch (Cross centroid 5)
 --     C.stroke
 -- :}
--- docs/haddock/Geometry/Core/polygon_centroid.svg
+-- Generated file: size 2KB, crc32: 0x4453ccc1
 polygonCentroid :: Polygon -> Vec2
 polygonCentroid poly@(Polygon ps) = weight *. vsum (zipWith (\p q -> cross p q *. (p +. q)) ps (tail (cycle ps)))
   where
@@ -1844,7 +1844,7 @@ polygonCircumference = foldl' (\acc edge -> acc + lineLength edge) 0 . polygonEd
 --         sketch (growPolygon (fromIntegral offset) polygon)
 --         C.stroke
 -- :}
--- docs/haddock/Geometry/Core/grow_polygon.svg
+-- Generated file: size 4KB, crc32: 0xd6cd58c1
 growPolygon :: Double -> Polygon -> Polygon
 growPolygon offset polygon =
     let oldEdges = polygonEdges polygon
@@ -1897,7 +1897,7 @@ growPolygon offset polygon =
 --         sketch (shrinkPolygon (fromIntegral offset) polygon)
 --         C.stroke
 -- :}
--- docs/haddock/Geometry/Core/shrink_polygon.svg
+-- Generated file: size 4KB, crc32: 0xc5085e44
 shrinkPolygon :: Double -> Polygon -> Polygon
 shrinkPolygon delta = growPolygon (-delta)
 
@@ -1980,7 +1980,7 @@ signedPolygonArea (Polygon ps)
 --         sketch polygon
 --         C.stroke
 -- :}
--- docs/haddock/Geometry/Core/is_convex.svg
+-- Generated file: size 2KB, crc32: 0x60a3e9a1
 isConvex :: Polygon -> Bool
 isConvex (Polygon ps) = allSameSign angleDotProducts
     -- The idea is that a polygon is convex iff all internal angles are in the
@@ -2011,7 +2011,7 @@ isConvex (Polygon ps) = allSameSign angleDotProducts
 --     sketch line >> C.stroke
 --     sketch bisector >> setColor (mathematica97 1) >> C.stroke
 -- :}
--- docs/haddock/Geometry/Core/perpendicular_bisector.svg
+-- Generated file: size 2KB, crc32: 0x1f7d2821
 perpendicularBisector :: Line -> Line
 perpendicularBisector line@(Line start end) = perpendicularLineThrough middle line
   where
@@ -2036,7 +2036,7 @@ perpendicularBisector line@(Line start end) = perpendicularLineThrough middle li
 --     sketch (Circle point 5) >> C.fill
 --     sketch perpendicular >> C.stroke
 -- :}
--- docs/haddock/Geometry/Core/perpendicular_line_through.svg
+-- Generated file: size 2KB, crc32: 0xb8e5d1d9
 perpendicularLineThrough :: Vec2 -> Line -> Line
 perpendicularLineThrough p line@(Line start _) = centerLine line'
   where
@@ -2096,7 +2096,7 @@ perpendicularLineThrough p line@(Line start _) = centerLine line'
 --            sketch ray'
 --            C.stroke
 -- :}
--- docs/haddock/Geometry/Core/reflection.svg
+-- Generated file: size 9KB, crc32: 0x76885f25
 reflection
     :: Line -- ^ Light ray
     -> Line -- ^ Mirror

--- a/src/Geometry/Processes/Billard.hs
+++ b/src/Geometry/Processes/Billard.hs
@@ -55,7 +55,7 @@ import Geometry.Core
 -- >>>         let billardArrows = zipWith Line billardPoints (tail billardPoints)
 -- >>>         for_ billardArrows $ \arr -> sketch arr >> C.stroke
 -- :}
--- docs/haddock/Geometry/Processes/Billard/billard.svg
+-- Generated file: size 80KB, crc32: 0xd6e508bf
 billard
     :: [Line] -- ^ Geometry; typically involves the edges of a bounding polygon.
     -> Line   -- ^ Initial velocity vector of the ball. Only start and direction,

--- a/src/Geometry/Shapes.hs
+++ b/src/Geometry/Shapes.hs
@@ -38,7 +38,7 @@ import Geometry.Core
 --         sketch (transform (translate (Vec2 10 10) <> scale 80) polygon)
 --         C.stroke
 -- :}
--- docs/haddock/Geometry/Shapes/haskell_logo.svg
+-- Generated file: size 3KB, crc32: 0x98aab3be
 --
 -- >>> all (\polygon -> polygonOrientation polygon == PolygonPositive) haskellLogo
 -- True
@@ -74,7 +74,7 @@ haskellLogoRaw = [left, lambda, upper, lower]
 --     sketch polygon
 --     C.stroke
 -- :}
--- docs/haddock/Geometry/Shapes/spiral_polygon.svg
+-- Generated file: size 2KB, crc32: 0x7b879da5
 --
 -- >>> polygonOrientation (spiralPolygon 8 10) == PolygonPositive
 -- True
@@ -108,7 +108,7 @@ spiralPolygon n width = Polygon (reverse (scanl (+.) (Vec2 0 0) relativeSpiral))
 --     sketch polygon
 --     C.stroke
 -- :}
--- docs/haddock/Geometry/Shapes/regular_pentagon.svg
+-- Generated file: size 2KB, crc32: 0x43d94b0e
 --
 -- >>> polygonOrientation (regularPolygon 5) == PolygonPositive
 -- True

--- a/src/Numerics/Optimization/TSP.hs
+++ b/src/Numerics/Optimization/TSP.hs
@@ -131,7 +131,7 @@ pathToPoints coordinates indices = V.backpermute coordinates (coerce indices)
 --        sketch tour
 --        stroke
 -- :}
--- docs/haddock/Numerics/Optimization/TSP/input_path.svg
+-- Generated file: size 11KB, crc32: 0xde10a233
 inputPath :: Vector a -> Vector TspPoint
 inputPath = (coerce :: Vector Int -> Vector TspPoint) . V.enumFromN 0 . V.length
 
@@ -163,7 +163,7 @@ inputPath = (coerce :: Vector Int -> Vector TspPoint) . V.enumFromN 0 . V.length
 --        sketch tour
 --        stroke
 -- :}
--- docs/haddock/Numerics/Optimization/TSP/nearest_neighbour_path.svg
+-- Generated file: size 11KB, crc32: 0x1474da44
 tspNearestNeighbourPath :: Distances -> Vector TspPoint
 tspNearestNeighbourPath dm = V.create $ do
     let n = size dm
@@ -471,7 +471,7 @@ tsp3optInplace dm path = loop0
 --        sketch tour
 --        stroke
 -- :}
--- docs/haddock/Numerics/Optimization/TSP/2-opt.svg
+-- Generated file: size 11KB, crc32: 0x73c4af54
 tsp2optPath :: Distances -> Vector TspPoint -> Vector TspPoint
 tsp2optPath dm = V.modify (tsp2optInplace dm)
 
@@ -504,6 +504,6 @@ tsp2optPath dm = V.modify (tsp2optInplace dm)
 --        sketch tour
 --        stroke
 -- :}
--- docs/haddock/Numerics/Optimization/TSP/3-opt.svg
+-- Generated file: size 11KB, crc32: 0x6c4e9493
 tsp3optPath :: Distances -> Vector TspPoint -> Vector TspPoint
 tsp3optPath dm = V.modify (tsp3optInplace dm)


### PR DESCRIPTION
To do:

- [x] Decide whether the performance hit for doctests is worth it.
  - Before: 15s
  - After: 1-3s slower
  - Worth it for the additional reporting I think! Can easily be removed again as well.
- [x] Fix 213 doctests :grimacing: 